### PR TITLE
mac(apps): Removed 1password

### DIFF
--- a/mac
+++ b/mac
@@ -197,7 +197,6 @@ rm -rf fonts
 brew cask install google-chrome
 brew cask install iterm2
 brew cask install atom
-brew cask install 1password
 brew cask install the-unarchiver
 brew cask install flux
 


### PR DESCRIPTION
Due to the downloaded version of 1password not supporting icloud sync it
has been removed, it must now be manually downloaded.